### PR TITLE
Add Travis CI builds for macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,39 @@
 language: python
 
-os:
-  - linux
-
-python:
-  - "3.6"
-  - "3.7"
-  - "3.8"
-  - "3.9-dev"
-  - "nightly"
+jobs:
+  include:
+    - os: linux
+      python: "3.6"
+    - os: linux
+      python: "3.7"
+    - os: linux
+      python: "3.8"
+    - os: linux
+      python: "3.9-dev"
+    - os: linux
+      python: "nightly"
+    - name: "Python 3.7.7 on macOS 10.14"
+      os: osx
+      osx_image: xcode11.2
+      language: shell
+    - name: "Python 3.8.5 on macOS 10.14"
+      os: osx
+      osx_image: xcode12.2
+      language: shell
 
 addons:
   apt:
-    packages:
-      - direnv
+    packages: direnv
+  homebrew:
+    packages: direnv
 
 before_install:
-  - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get install direnv                        ; fi
-  - if [ $TRAVIS_OS_NAME = linux ]; then echo 'eval "$(direnv hook bash)"' > ~/.bashrc      ; fi
+  - sh ./.travis/before_install.sh
 
 install:
   - direnv allow
   - make requirements
-  - pip install codecov
+  - pip3 install codecov
 
 script:
   - coverage run -m pytest

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Create a .bashrc file
+touch ~/.bashrc;
+
+# Add direnv hooks
+echo 'eval "$(direnv hook bash)"' > ~/.bashrc;
+
+# Print the Python version
+echo $(python3 --version)


### PR DESCRIPTION
Tried different methods including using `pyenv`, as well as `pyenv-virtualenv`, and `tox` to execute Travis CI builds with different Python versions - all of these failed.

Settled on a method based on this [Travis CI blog](https://blog.travis-ci.com/2019-08-07-extensive-python-testing-on-travis-ci), with a more up-to-date [GitHub gist](https://gist.github.com/shaypal5/7fd766933fb265af6f71a88cb91dd08c), which works. Comprise is that it can only test macOS builds on Python 3.7 and 3.8, whereas Python 3.6+ is tested on Linux.