### PR TITLE
Bugfix broken CountAPI URL

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -22,8 +22,8 @@ export GITHUB_REPOSITORY=https://github.com/ESKYoung/shields-io-visitor-counter
 # Define the flask app
 export FLASK_APP=main.py
 
-# Define the hashing key
-export HASH_KEY=
+# Define the hashing key here if using locally. If using on Heroku, define it in config vars
+# export HASH_KEY=
 
 # Define the CountAPI URL
 export URL_COUNTAPI=https://api.countapi.xyz/hit/shields-io-visitor-counter

--- a/main.py
+++ b/main.py
@@ -76,7 +76,7 @@ def get_page_count(key: str) -> Optional[int]:
     try:
 
         # Get the count from CountAPI
-        countapi_response = requests.get(combine_url_and_query(URL_COUNTAPI, key))
+        countapi_response = requests.get(f"{URL_COUNTAPI}/{key}")
 
         # Check a correct return is supplied
         if countapi_response and countapi_response.status_code == 200:
@@ -136,7 +136,7 @@ def get_shields_io_badge() -> Union[Response, Tuple[str, int]]:
         # Get the page hash
         page_hash = get_page_hash(request_arguments.pop("page"))
 
-        # Get the page count from COUNT API, and assert it is not empty
+        # Get the page count from CountAPI, and assert it is not empty
         message = get_page_count(page_hash[:64])
         assert message
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 addopts = -vv --doctest-modules
 doctest_optionflags = NORMALIZE_WHITESPACE
+env =
+    HASH_KEY=pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ gunicorn
 hypothesis
 pre-commit
 pytest
+pytest-env
 pytest-mock
 pytest-xdist
 requests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,5 +9,5 @@ def patch_flask_redirect(mocker):
 
 @pytest.fixture(scope="session")
 def patch_requests_get(session_mocker):
-    """Patch the request.get function"""
+    """Patch the request.get function."""
     return session_mocker.patch("requests.get")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -95,7 +95,7 @@ def test_get_page_count_calls_countapi_correctly(patch_requests_get: MagicMock, 
     _ = get_page_count(test_input)
 
     # Assert the requests.get function is called once with the correct argument
-    patch_requests_get.assert_called_with(combine_url_and_query(URL_COUNTAPI, test_input))
+    patch_requests_get.assert_called_with(f"{URL_COUNTAPI}/{test_input}")
 
 
 def mock_requests_get(*args: Any) -> object:
@@ -136,8 +136,8 @@ def mock_requests_get(*args: Any) -> object:
             """
             return self.json_data
 
-    # Define the MockResponse attributes if the URL stub is "" or otherwise
-    if args[0] != URL_COUNTAPI:
+    # Define the MockResponse attributes if the URL stub is whitespace or otherwise empty
+    if args[0].rstrip(" /") != URL_COUNTAPI:
         return MockResponse({"value": 100}, 200)
     else:
         return MockResponse(None, 404)
@@ -151,7 +151,7 @@ def test_get_page_count_returns_correctly_with_working_countapi(patch_requests_g
     patch_requests_get.side_effect = mock_requests_get
 
     # Call the get_page_count function, and assert the returned value is correct
-    if combine_url_and_query(URL_COUNTAPI, test_input) != URL_COUNTAPI:
+    if test_input.rstrip(" /"):
         assert get_page_count(test_input) == 100
     else:
         assert get_page_count(test_input) is None


### PR DESCRIPTION
Issue with key URL slug not being added correct for CountAPI. Fixed now, along with associated tests.

Also commented out the `HASH_KEY` environment variable in favour of using Heroku's config vars. Added the `pytest-env` package to handle this variable for testing.