### PR TITLE
Add cron page to application

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -25,6 +25,9 @@ export FLASK_APP=main.py
 # Define the hashing key here if using locally. If using on Heroku, define it in config vars
 # export HASH_KEY=
 
+# Define HTML pages
+export HTML_CRON=cron.html
+
 # Define the CountAPI URL
 export URL_COUNTAPI=https://api.countapi.xyz/hit/shields-io-visitor-counter
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-10-17T11:10:15Z",
+  "generated_at": "2020-10-18T09:20:33Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -63,28 +63,28 @@
         "hashed_secret": "65b5658c038dcc7b3f9ee80669c0f26ac1441d05",
         "is_secret": true,
         "is_verified": false,
-        "line_number": 55,
+        "line_number": 58,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "5e18621e95bc4b9b75d7d5b097929ecfc9494078",
         "is_secret": true,
         "is_verified": false,
-        "line_number": 56,
+        "line_number": 59,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "2b2718d1211a6b3c6ae4ef13c63469cb1eafa6c7",
         "is_secret": true,
         "is_verified": false,
-        "line_number": 57,
+        "line_number": 60,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "186df42ce44b6dc5a79c097baf114cf67eb9a13b",
         "is_secret": true,
         "is_verified": false,
-        "line_number": 58,
+        "line_number": 61,
         "type": "Hex High Entropy String"
       }
     ]

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
-from flask import Flask, Response, redirect, request
-from typing import Dict, Optional, Tuple, Union
+from flask import Flask, Response, redirect, render_template, request
+from typing import Any, Dict, Optional, Tuple, Union
 from urllib.parse import SplitResult, urlsplit, urlunsplit
 import hashlib
 import os
@@ -12,6 +12,7 @@ DEFAULT_SHIELDS_IO_LABEL = os.getenv("DEFAULT_SHIELDS_IO_LABEL")
 DEFAULT_SHIELDS_IO_COLOR = os.getenv("DEFAULT_SHIELDS_IO_COLOR")
 GITHUB_REPOSITORY = os.getenv("GITHUB_REPOSITORY")
 HASH_KEY = os.getenv("HASH_KEY")
+HTML_CRON = os.getenv("HTML_CRON")
 URL_COUNTAPI = os.getenv("URL_COUNTAPI").rstrip("/")
 URL_SHIELDS_IO = os.getenv("URL_SHIELDS_IO").rstrip("/")
 
@@ -173,6 +174,17 @@ def get_shields_io_badge() -> Union[Response, Tuple[str, int]]:
 
     # Return the badge to the user
     return Response(response=svg, content_type="image/svg+xml", headers=headers)
+
+
+@app.route("/cron")
+def cron_page() -> Tuple[Any, int]:
+    """Add a page for cron jobs to wake up the application.
+
+    Returns:
+        A HTTP no content status code.
+
+    """
+    return render_template(HTML_CRON)
 
 
 if __name__ == '__main__':

--- a/templates/cron.html
+++ b/templates/cron.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Hello &#128075</title>
+</head>
+<body>
+    <h1>I'm awake! &#128075</h1>
+
+</body>
+</html>


### PR DESCRIPTION
Allows for cron jobs to ping the application without incorrectly adding to an existing counter, or unnecessarily pinging CountAPI.