### PR TITLE
Fix typos in codebase

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,10 +60,10 @@ information.
 The entire application can be found in [`main.py`](./main.py), with its associated tests in the [`tests`](./tests)
 folder; tests are executed using [pytest][pytest]
 
-Travis CI deployment is managed by the [`.travis.yml`](./.travis.yml) file - see the [Deployment](#deployment)
+Travis CI deployment is managed by the [`.travis.yml`](./.travis.yml) file — see the [Deployment](#deployment)
 section for further details.
 
-The application uses environment variables extensively - see the [Environment variables](#environment-variables)
+The application uses environment variables extensively — see the [Environment variables](#environment-variables)
 section for further details.
 
 ### Environment variables

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ A simple visitor counter displayed as a Shields.IO static badge.
 ## How it works
 
 This application is deployed on Heroku, and creates a Shields.IO static badge that you can embed on your page. Every
-time you page loads, it reloads the badge, which pings [CountAPI][countapi] to increase the counter!
+time your page loads, it reloads the badge, which pings [CountAPI][countapi] to increase the counter!
 
-### Creating your own visitor counter
+## Creating your own visitor counter
 
 If you've used [Shields.IO][shields-io] before, it's really straightforward! Let's use the
 [octocat/Spoon-Knife][spoon-knife] GitHub repository as an example.
@@ -33,7 +33,7 @@ And to embed this in Markdown, just use:
 ![Visitor count](https://shields-io-visitor-counter.herokuapp.com/badge?page=octocat.Spoon-Knife)
 ```
 
-#### Options
+### Options
 
 The only mandatory argument is `page`, but you can use _almost_ all options available on [Shields.IO][shields-io] — the
 only unavailable one is `message`, as this is the count! To add option, just add it to URL query component.
@@ -64,7 +64,7 @@ which gives us:
 Note we used hex colours in the URL, but [Shields.IO][shields-io] also supports (some) colours by name!
 
 
-### Caveats
+## Caveats
 
 - It's not smart enough to track users by IP address, for example. So if you reload the page, the counter will also
   increase!

--- a/main.py
+++ b/main.py
@@ -177,7 +177,7 @@ def get_shields_io_badge() -> Union[Response, Tuple[str, int]]:
 
 
 @app.route("/cron")
-def cron_page() -> Tuple[Any, int]:
+def cron_page() -> Any:
     """Add a page for cron jobs to wake up the application.
 
     Returns:


### PR DESCRIPTION
Fix minor typos in both README.md and CONTRIBUTING.md, and a type hinting typo in `main.py`.