### PR TITLE
fix: resolve broken Heroku deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ script:
 after_success:
   - codecov
 
+before_deploy:
+  - rvm $(travis_internal_ruby) --fuzzy do ruby -S gem install faraday -v 1.8.0
+
 deploy:
   provider: heroku
   api_key:


### PR DESCRIPTION
Heroku isn't deploying due to an issue with its `dpl-heroku` dependency, and a gem called `faraday`. Hopefully this will fix it.

Based on answer at:
https://travis-ci.community/t/heroku-deploy-fails-installing-dpl-heroku-encounters-faraday-error/12563/6